### PR TITLE
Fix get_rusage function by changing ffi_lib() call in LibC module

### DIFF
--- a/lib/ffi/libc/libc.rb
+++ b/lib/ffi/libc/libc.rb
@@ -10,7 +10,7 @@ module FFI
   module LibC
     extend FFI::Library
 
-    ffi_lib [FFI::CURRENT_PROCESS, 'c']
+    ffi_lib FFI::Library::LIBC
 
     NULL = nil
 


### PR DESCRIPTION
I do not know why this works. Please merge it and bump the version ASAP, I need this for internal stuff.
